### PR TITLE
Support Windows

### DIFF
--- a/numba4jax/_src/backends/_cuda.py
+++ b/numba4jax/_src/backends/_cuda.py
@@ -10,9 +10,11 @@ try:
 
     if sys.platform == "win32":
         import ctypes.util
+
         libcuda_path = ctypes.util.find_library(_libcuda._name)
     else:
         from numba4jax._src.c_api import find_path_of_symbol_in_library
+
         libcuda_path = find_path_of_symbol_in_library(_libcuda.cuMemcpy)
 
     numba_cffi_loaded = True

--- a/numba4jax/_src/backends/_cuda.py
+++ b/numba4jax/_src/backends/_cuda.py
@@ -1,17 +1,22 @@
+import sys
+
 from numba import cuda as ncuda
 from cffi import FFI
 
 from numba import types as nb_types
 
-from numba4jax._src.c_api import find_path_of_symbol_in_library
-
 try:
     _libcuda = ncuda.driver.find_driver()
 
-    libcuda_path = find_path_of_symbol_in_library(_libcuda.cuMemcpy)
+    if sys.platform == "win32":
+        import ctypes.util
+        libcuda_path = ctypes.util.find_library(_libcuda._name)
+    else:
+        from numba4jax._src.c_api import find_path_of_symbol_in_library
+        libcuda_path = find_path_of_symbol_in_library(_libcuda.cuMemcpy)
 
     numba_cffi_loaded = True
-except:
+except ValueError:
     numba_cffi_loaded = False
 
 if numba_cffi_loaded:

--- a/numba4jax/_src/c_api.py
+++ b/numba4jax/_src/c_api.py
@@ -51,7 +51,7 @@ class Dl_info(ctypes.Structure):
     )
 
 
-# Find the dynamic linker library path
+# Find the dynamic linker library path. Only works on unix-like os
 libdl_path = ctypes.util.find_library("dl")
 if libdl_path:
     # Load the dynamic linker dynamically


### PR DESCRIPTION
On Windows we need to find CUDA libraries without using `libdl`.